### PR TITLE
Changes for cross-tenant access integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Ensure you have the following privileges before you execute the Terraform Script
 * Administrative roles:
   * Global administrator
 
-* User Access Administrator Role to the Root.
+* Owner Role to the Root.
 
     For more information visit: [https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin]
 
@@ -67,6 +67,9 @@ To execute the Terraform script:
        set_tenant_level_permissions = true
 
        root_management_group_id = "ID of the root management group in a tenant"
+
+       # Find the client_id on Azure Integration page of Uptycs Web
+       uptycs_app_client_id = "Client ID from Azure Integration page"
    }
 
    output "tenant_id" {
@@ -83,6 +86,7 @@ To execute the Terraform script:
    | resource_name                | The names of the new resources                                       | `string` | `UptycsIntegration-123` |
    | set_tenant_level_permissions    | The flag to choose permissions at tenant level or subscription level | `bool`   | `true`                              |
    | root_management_group_id | The ID of the root management group                                  | `string` | Required                            |
+   | uptycs_app_client_id | The Client ID of Uptycs multi-tenant app                                  | `string` | Required                            |
 
    ### Outputs
 
@@ -91,8 +95,8 @@ To execute the Terraform script:
    | tenantId | Tenant ID   |
 
    ```
-   $ terraform init
+   $ terraform init --upgrade
    $ terraform plan  # Please verify before applying
    $ terraform apply
-   # Once terraform successfully applied, it will create "credentials.json" file
+   # Wait until successfully completed
    ```

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,8 @@
-data "azuread_application_published_app_ids" "app_ids" {}
+data "azuread_application_published_app_ids" "well_known" {}
 
 data "azurerm_client_config" "current" {}
 
+# Get the Management Group
 data "azurerm_management_group" "parent_management_group" {
   name = var.root_management_group_id
 }

--- a/providers.tf
+++ b/providers.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.29.1"
+      version = ">= 3.39.1"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">= 2.3.0"
+      version = ">= 2.32.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,3 +12,8 @@ variable "root_management_group_id" {
   description = "ID of the Root Management Group"
   type        = string
 }
+
+variable "uptycs_app_client_id" {
+  description = "Client ID of Uptycs Multitenant App"
+  type = string
+}


### PR DESCRIPTION
New changes do the following:
- Create a service principal for multi-tenant Uptycs App instead of app registration
- Create role assignments for the service principal
- Add the service principal as a reader to the Management Group IAM