### PR TITLE
CSM-8630: Azure org terraform : source code is pointing to github instead of terraform registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To execute the Terraform script:
 
    ```
    module "azure-org-config" {
-       source = "github.com/uptycslabs/terraform-azurerm-tenant-integration"
+       source = "uptycslabs/tenant-integration/azurerm"
 
        # modify as per your requirement
        resource_name = "UptycsIntegration-123"


### PR DESCRIPTION
Changed the source in readme from git repository to terraform registry

**TestCase:**

- [x] Run the terraform with git repository as source and change source to registry run terraform no configuration should change

- [x] Destroy earlier terraform and run with source as registry it should work