### PR TITLE
CSM-13936: Fixing the hyperlink in the Azure Tenant Integration TF Registry page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Ensure you have the following privileges before you execute the Terraform Script
   - `Application Administrator` (AD Role)
 - `Owner` role at the Root Management Group scope
 
-  For more information, refer to [https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin].
+  For more information on how to enable Access Control (IAM) for Root Management Group, refer to [this link](https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin).
 
 Absence of the above privileges may result in access related issues when trying to run the Terraform.
 


### PR DESCRIPTION
### Description:
  * JIRA: https://uptycsjira.atlassian.net/browse/CSM-13936
  * The hyperlink to the Official Microsoft Azure documentation is malformed and improper. When clicked upon, it fails to load anything in the brower. The reason is a fault `]` (square bracket) at the end which is included in the hyperlink.
  * Fixed the hyper link and updated the wordings to explain what it really is showing.
  * Below is how it would look in a markdown file:
  ![Screenshot from 2023-12-07 12-35-10](https://github.com/uptycslabs/terraform-azurerm-tenant-integration/assets/93505703/0c90755e-0b87-4300-bab0-108a06b71081)
  