### PR TITLE
CSM-13935: Fix warnings that show up during Azure integration terraform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,13 +4,13 @@ locals {
 
 # Get MSGraph App
 resource "azuread_service_principal" "msgraph" {
-  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-  use_existing   = true
+  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing = true
 }
 
 # Create a service principal for the Uptycs App 
 resource "azuread_service_principal" "service_principal" {
-  application_id = var.uptycs_app_client_id
+  client_id = var.uptycs_app_client_id
 }
 
 # Create Graph API related permissions to the service principal

--- a/variables.tf
+++ b/variables.tf
@@ -15,5 +15,5 @@ variable "root_management_group_id" {
 
 variable "uptycs_app_client_id" {
   description = "Client ID of Uptycs Multitenant App"
-  type = string
+  type        = string
 }


### PR DESCRIPTION
We are using one variable in azure ad provider. That is going to be depreciated in future. This varible name will be changed
We are hitting this warning
```
Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Argument is deprecated
│ 
│   with module.iam-config.azuread_service_principal.msgraph,
│   on .terraform/modules/iam-config/main.tf line 3, in resource "azuread_service_principal" "msgraph":
│    3:   application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
│ 
│ The `application_id` property has been replaced with the `client_id` property and will be removed in version 3.0 of the AzureAD provider
│ 
│ (and one more similar warning elsewhere)
╵
```
Changed the variable name in our module

Test Cases:

- [x] Changed the variable in module run terraform apply. No warning
- [x] To test the regression re run the terraform after this change. No issue